### PR TITLE
Fix table references

### DIFF
--- a/06-statistical-testing.Rmd
+++ b/06-statistical-testing.Rmd
@@ -505,7 +505,7 @@ The output from `svychisq()` indicates that the distribution of people's trust i
 chi_ex2$observed
 ```
 
-However, as researchers, we often want to know about the proportions and not just the respondent counts from the survey. There are a couple of different ways that we can do this. The first is using the counts from `chi_ex2$observed` to calculate the proportion. We can then pivot the table to create a cross-tabulation similar to the counts table above. Adding `group_by()` to the code means that we are obtaining the proportions within each level of that variable. In this case, we are looking at the distribution of `TrustGovernment` for each level of `TrustPeople`.
+However, as researchers, we often want to know about the proportions and not just the respondent counts from the survey. There are a couple of different ways that we can do this. The first is using the counts from `chi_ex2$observed` to calculate the proportion. We can then pivot the table to create a cross-tabulation similar to the counts table above. Adding `group_by()` to the code means that we are obtaining the proportions within each level of that variable. In this case, we are looking at the distribution of `TrustGovernment` for each level of `TrustPeople`. The resulting table is shown in Table \@ref(tab:stattest-chi-ex2-prop1-tab).
 
 ```{r}
 #| label: stattest-chi-ex2-prop1
@@ -534,12 +534,12 @@ chi_ex2_table
 (ref:stattest-chi-ex2-prop1-tab) Estimates of proportion of people by levels of trust in people and government, ANES 2020
 
 ```{r}
-#| label: stattest-chi-ex2-prop1-out
+#| label: stattest-chi-ex2-prop1-tab
 #| echo: FALSE
 #| warning: FALSE
 
 chi_ex2_table %>%
-    print_gt_book("stattest-chi-ex2-prop1-tab")
+    print_gt_book(knitr::opts_current$get()[["label"]])
 ```
 
 
@@ -574,12 +574,12 @@ chi_ex2_obs_table
 (ref:stattest-chi-ex2-prop2-tab) Estimates of proportion of people by levels of trust in people and government with confidence intervals, ANES 2020
 
 ```{r}
-#| label: stattest-chi-ex2-prop2-out
+#| label: stattest-chi-ex2-prop2-tab
 #| echo: FALSE
 #| warning: FALSE
 
 chi_ex2_obs_table %>%
-    print_gt_book("stattest-chi-ex2-prop2-tab")
+    print_gt_book(knitr::opts_current$get()[["label"]])
 ```
 
 Both methods produce the same output as the `svychisq()` function does account for the survey design. However, calculating the proportions directly from the design object means we can also obtain the variance information. In this case, the table output displays the survey estimate followed by the confidence intervals. Based on the output, we can see that of those who never trust people, 50.3% also never trust the government, while the proportions of never trusting the government are much lower for each of the other levels of trusting people. 
@@ -670,12 +670,12 @@ chi_ex3_obs_table
 (ref:stattest-chi-ex3-tab) Distribution of age group by presidential candidate selection with confidence intervals
 
 ```{r}
-#| label: stattest-chi-ex3-table-out
+#| label: stattest-chi-ex3-tab
 #| echo: FALSE
 #| warning: FALSE
 
 chi_ex3_obs_table %>%
-    print_gt_book("stattest-chi-ex3-tab")
+    print_gt_book(knitr::opts_current$get()[["label"]])
 ```
 
 We can see that the age group distribution was younger for Biden and other candidates and older for Trump. For example, of those who voted for Biden, 20.4% were in the 18-29 age group, compared to only 11.4% of those who voted for Trump were in that age group. On the other side, 23.4% of those who voted for Trump were in the 50-59 age group compared to only 15.4% of those who voted for Biden.

--- a/08-communicating-results.Rmd
+++ b/08-communicating-results.Rmd
@@ -147,12 +147,12 @@ trust_gov_gt %>%
 (ref:results-table-gt1-tab) Example of gt table with trust in government estimate
 
 ```{r}
-#| label: results-table-gt1-out
+#| label: results-table-gt1-tab
 #| echo: FALSE
 #| warning: FALSE
 
 trust_gov_gt %>%
-  print_gt_book("results-table-gt1-tab")
+  print_gt_book(knitr::opts_current$get()[["label"]])
 ```
 
 We can add a few more enhancements, such as a title, a data source note, and a footnote with the question information, using the functions `tab_header()`, `tab_source_note()`, and `tab_footnote()`. If having the percentage sign in both the header and the cells seems redundant, we can opt for `fmt_number()` instead of `fmt_percent()` and scale the number by 100 with `scale_by = 100`.
@@ -180,12 +180,12 @@ trust_gov_gt2
 (ref:results-table-gt2-tab) Example of gt table with trust in government estimates and additional context
 
 ```{r}
-#| label: results-table-gt2-out
+#| label: results-table-gt2-tab
 #| echo: FALSE
 #| warning: FALSE
 
 trust_gov_gt2 %>%
-  print_gt_book("results-table-gt2-tab")
+  print_gt_book(knitr::opts_current$get()[["label"]])
 ```
 
 #### Expanding tables using {gtsummary} {-}
@@ -232,12 +232,12 @@ anes_des_gtsum
 (ref:results-gts-ex-1-tab) Example of gtsummary table with trust in government estimates
 
 ```{r}
-#| label: results-gts-ex-1-out
+#| label: results-gts-ex-1-tab
 #| echo: FALSE
 #| warning: FALSE
 
 anes_des_gtsum %>%
-  print_gt_book("results-gts-ex-1-tab")
+  print_gt_book(knitr::opts_current$get()[["label"]])
 ```
 
 The default table includes the weighted number of missing (or Unknown) records. The standard error is reported as a proportion, while the proportion is styled as a percentage. In the next step, we remove the Unknown category by setting the missing argument to "no" and format the standard error as a percentage using the `digits` argument. To improve the table for publication, we provide a more polished label for the "TrustGovernment" variable using the `label` argument.
@@ -263,12 +263,12 @@ anes_des_gtsum2
 (ref:results-gts-ex-2-tab) Example of gtsummary table with trust in government estimates with labeling and digits options
 
 ```{r}
-#| label: results-gts-ex-2-out
+#| label: results-gts-ex-2-tab
 #| echo: FALSE
 #| warning: FALSE
 
 anes_des_gtsum2 %>%
-  print_gt_book("results-gts-ex-2-tab")
+  print_gt_book(knitr::opts_current$get()[["label"]])
 ```
 
 To exclude the term "Characteristic" and the estimated population size, we can modify the header using the`modify_header()` function to update the `label`. Further adjustments can be made based on personal preferences, organizational guidelines, or other style guides. If we prefer having the standard error in the header, similar to the {gt} table, instead of in the footnote (the {gtsummary} default), we can make these changes by specifying `stat_0` in the `modify_header()` function. Additionally, using `modify_footnote()` with `update = everything() ~ NA` removes the standard error from the footnote. After transforming the object into a gt table using `as_gt()`, we can add footnotes and a title using the same methods explained in Section \@ref(results-gt).
@@ -306,12 +306,12 @@ anes_des_gtsum3
 (ref:results-gts-ex-3-tab) Example of gtsummary table with trust in government estimates with more labeling options and context
 
 ```{r}
-#| label: results-gts-ex-3-out
+#| label: results-gts-ex-3-tab
 #| echo: FALSE
 #| warning: FALSE
 
 anes_des_gtsum3 %>%
-  print_gt_book("results-gts-ex-3-tab")
+  print_gt_book(knitr::opts_current$get()[["label"]])
 ```
 
 We can also include continuous variables in the table. Below, we add a summary of the age variable by updating the `include`, `statistic`, and `digits` arguments.
@@ -354,12 +354,12 @@ anes_des_gtsum4
 (ref:results-gts-ex-4-tab) Example of gtsummary table with trust in government estimates and average age
 
 ```{r}
-#| label: results-gts-ex-4-out
+#| label: results-gts-ex-4-tab
 #| echo: FALSE
 #| warning: FALSE
 
 anes_des_gtsum4 %>%
-  print_gt_book("results-gts-ex-4-tab")
+  print_gt_book(knitr::opts_current$get()[["label"]])
 ```
 
 With {gtsummary}, we can also calculate statistics by different groups. Let's modify the previous example to analyze data on whether a respondent voted for president in 2020. We update the `by` argument and refine the header.
@@ -403,12 +403,12 @@ anes_des_gtsum5
 (ref:results-gts-ex-5-tab) Example of gtsummary table with trust in government estimates by voting status
 
 ```{r}
-#| label: results-gts-ex-5-out
+#| label: results-gts-ex-5-tab
 #| echo: FALSE
 #| warning: FALSE
 
 anes_des_gtsum5 %>%
-    print_gt_book("results-gts-ex-5-tab")
+    print_gt_book(knitr::opts_current$get()[["label"]])
 ```
 
 ### Charts and plots

--- a/13-ncvs-vignette.Rmd
+++ b/13-ncvs-vignette.Rmd
@@ -700,10 +700,10 @@ pers_des %>%
   ))
 ```
 
-A common desire is to calculate victimization rates by several characteristics. For example, we may want to calculate the violent victimization rate and aggravated assault rate by sex, race/Hispanic origin, age group, marital status, and household income. This requires a `group_by()` statement for each categorization separately. Thus, we make a function to do this and then use `map_df()` from the {purrr} package (part of the tidyverse) to loop through the variables. Finally, the {gt} package is used to make a publishable table.
+A common desire is to calculate victimization rates by several characteristics. For example, we may want to calculate the violent victimization rate and aggravated assault rate by sex, race/Hispanic origin, age group, marital status, and household income. This requires a `group_by()` statement for each categorization separately. Thus, we make a function to do this and then use `map_df()` from the {purrr} package (part of the tidyverse) to loop through the variables. Finally, the {gt} package is used to make a publishable table shown in Table \@ref(tab:ncvs-vign-rates-demo-tab).
 
 ```{r}
-#| ncvs-vign-rates-demo
+#| label: ncvs-vign-rates-demo
 pers_est_by <- function(byvar) {
   pers_des %>%
     rename(Level := {{byvar}}) %>%
@@ -792,12 +792,12 @@ vr_gt
 (ref:ncvs-vign-rates-demo-tab) Rate and standard error of violent victimization, by type of crime and demographic characteristics, 2021
 
 ```{r}
-#| label: ncvs-vign-rates-demo-out
+#| label: ncvs-vign-rates-demo-tab
 #| echo: FALSE
 #| warning: FALSE
 
 vr_gt %>%
-    print_gt_book("ncvs-vign-rates-demo-tab")
+    print_gt_book(knitr::opts_current$get()[["label"]])
 ```
 
 ### Estimation 4: Prevalence Rates {#prev-rate}

--- a/14-ambarom-vignette.Rmd
+++ b/14-ambarom-vignette.Rmd
@@ -158,7 +158,7 @@ One interesting thing to note is that these can only give us estimates to compar
 
 This survey was administered in 2021 between March and August, varying by country^[See Table 2 in @lapop-tech for dates by country]. Given the state of the pandemic at that time, several questions about COVID were included. The first question about COVID asked whether people were worried about the possibility that they or someone in their household will get sick from coronavirus in the next three months. We will calculate the percentage of people in each country who are very worried or somewhat worried. 
 
-In the following code, we calculate estimate for each country and then create a table of the estimates for display using the {gt} package.
+In the following code, we calculate estimate for each country and then create a table (see Table \@ref(tab:ambarom-est1-tab)) of the estimates for display using the {gt} package.
 
 ```{r}
 #| label: ambarom-est1
@@ -190,12 +190,12 @@ covid_worry_country_ests_gt
 (ref:ambarom-est1-tab) Proportion worried about the possibility that they or someone in their household will get sick from coronavirus in the next 3 months
 
 ```{r}
-#| label: ambarom-est1-out
+#| label: ambarom-est1-tab
 #| echo: FALSE
 #| warning: FALSE
 
 covid_worry_country_ests_gt %>%
-    print_gt_book("ambarom-est1-tab")
+    print_gt_book(knitr::opts_current$get()[["label"]])
 ```
 
 Another question asked how education was affected by the pandemic. This question was asked among households with children under the age of 13, and respondents could select more than one option as follows:
@@ -226,7 +226,7 @@ We might create multiple outcomes for a table as follows:
 - Indicator that school continued as normal with no virtual or hybrid option
 - Indicator that the education medium was changed - either virtual or hybrid
 
-In this next code chunk, we create these indicators, make national estimates, and display a summary table of the data.
+In this next code chunk, we create these indicators, make national estimates, and display a summary table of the data shown in Table \@ref(tab:ambarom-covid-ed-der-tab).
 
 ```{r}
 #| label: ambarom-covid-ed-der
@@ -274,12 +274,12 @@ covid_educ_ests_gt
 (ref:ambarom-covid-ed-der-tab) Impact on education in households with children under the age of 13 who had children that would generally attend school
 
 ```{r}
-#| label: ambarom-covid-ed-der-out
+#| label: ambarom-covid-ed-der-tab
 #| echo: FALSE
 #| warning: FALSE
 
 covid_educ_ests_gt %>%
-  print_gt_book("ambarom-covid-ed-der-tab")
+  print_gt_book(knitr::opts_current$get()[["label"]])
 ```
 
 Of the countries that used this question, many had households where their children had an education medium change, except Haiti, where only `r covid_educ_ests %>% filter(Country=="Haiti") %>% pull(p_mediumchange) %>% signif(.,2)`% of households with students changed to virtual or hybrid learning. 


### PR DESCRIPTION
This makes it so the table reference matches the chunk label where the table is printed. When referencing the table, use `\@ref(tab:chunk-name)` and create the caption as: `(ref:chunk-name) My awesome table caption`