### PR TITLE
Update download-artifact to V 4.1.7

### DIFF
--- a/.github/workflows/deploy_bookdown.yml
+++ b/.github/workflows/deploy_bookdown.yml
@@ -59,7 +59,7 @@ jobs:
      - name: Checkout
        uses: actions/checkout@main
      - name: Download artifact
-       uses: actions/download-artifact@v1.0.0
+       uses: actions/download-artifact@v4.1.7
        with:
          # Artifact name
          name: _book # optional


### PR DESCRIPTION
Updating because of a vulnerability: https://github.com/advisories/GHSA-cxww-7g56-2vh6 